### PR TITLE
Failed request should not be cached ( #461)

### DIFF
--- a/lib/src/cache/map_cache.dart
+++ b/lib/src/cache/map_cache.dart
@@ -41,9 +41,15 @@ class MapCache<K, V> implements Cache<K, V> {
     if (ifAbsent != null) {
       var futureOr = ifAbsent(key);
       _outstanding[key] = futureOr;
-      var v = await futureOr;
+      V v;
+      try {
+        v = await futureOr;
+      } finally {
+        // Always remove key from [_outstanding] to prevent returning the
+        // failed result again.
+        _outstanding.remove(key);
+      }
       _map[key] = v;
-      _outstanding.remove(key);
       return v;
     }
     return null;

--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -87,12 +87,14 @@ main() {
 
       Future<String> loader(String key) {
         count += 1;
-        return new Future.error("Request failed");
+        return new Future.error(new StateError("Request failed"));
       }
 
       await Future.wait(<Future>[
-        expectThrows(() => cache.get("test", ifAbsent: loader)),
-        expectThrows(() => cache.get("test", ifAbsent: loader)),
+        expect(() => cache.get("test", ifAbsent: loader),
+            throwsA(const TypeMatcher<StateError>())),
+        expect(() => cache.get("test", ifAbsent: loader),
+            throwsA(const TypeMatcher<StateError>())),
       ]);
 
       expect(count, equals(2));

--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -91,12 +91,8 @@ main() {
         throw new StateError("Request failed");
       }
 
-      await Future.wait(<Future>[
-        expectLater(
-            () => cache.get("test", ifAbsent: loader), throwsStateError),
-        expectLater(
-            () => cache.get("test", ifAbsent: loader), throwsStateError),
-      ]);
+      expect(await () => cache.get("test", ifAbsent: loader), throwsStateError);
+      expect(await () => cache.get("test", ifAbsent: loader), throwsStateError);
 
       expect(count, equals(2));
       expect(cache.get('test'), null);

--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -81,5 +81,21 @@ main() {
 
       expect(count, equals(1));
     });
+
+    test("should not cache a failed request", () async {
+      int count = 0;
+
+      Future<String> loader(String key) {
+        count += 1;
+        return new Future.error("Request failed");
+      }
+
+      await Future.wait([
+        expectThrows(() => cache.get("test", ifAbsent: loader)),
+        expectThrows(() => cache.get("test", ifAbsent: loader)),
+      ]);
+
+      expect(count, equals(2));
+    });
   });
 }

--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -15,8 +15,9 @@
 library quiver.cache.map_cache_test;
 
 import 'dart:async';
-import 'package:test/test.dart';
+
 import 'package:quiver/cache.dart';
+import 'package:test/test.dart';
 
 main() {
   group('MapCache', () {
@@ -91,8 +92,10 @@ main() {
       }
 
       await Future.wait(<Future>[
-        expect(() => cache.get("test", ifAbsent: loader), throwsStateError),
-        expect(() => cache.get("test", ifAbsent: loader), throwsStateError),
+        expectLater(
+            () => cache.get("test", ifAbsent: loader), throwsStateError),
+        expectLater(
+            () => cache.get("test", ifAbsent: loader), throwsStateError),
       ]);
 
       expect(count, equals(2));

--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -90,7 +90,7 @@ main() {
         return new Future.error("Request failed");
       }
 
-      await Future.wait([
+      await Future.wait(<Future>[
         expectThrows(() => cache.get("test", ifAbsent: loader)),
         expectThrows(() => cache.get("test", ifAbsent: loader)),
       ]);

--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -85,19 +85,18 @@ main() {
     test("should not cache a failed request", () async {
       int count = 0;
 
-      Future<String> loader(String key) {
+      Future<String> loader(String key) async {
         count += 1;
-        return new Future.error(new StateError("Request failed"));
+        throw new StateError("Request failed");
       }
 
       await Future.wait(<Future>[
-        expect(() => cache.get("test", ifAbsent: loader),
-            throwsA(const TypeMatcher<StateError>())),
-        expect(() => cache.get("test", ifAbsent: loader),
-            throwsA(const TypeMatcher<StateError>())),
+        expect(() => cache.get("test", ifAbsent: loader), throwsStateError),
+        expect(() => cache.get("test", ifAbsent: loader), throwsStateError),
       ]);
 
       expect(count, equals(2));
+      expect(cache.get('test'), null);
     });
   });
 }


### PR DESCRIPTION
If a [futureOr] fails, [_outstanding] caches it. Therefore, the next time, it returns the cached failed request from [_outstanding].

With this fix, a failed [futureOr] is never cached.

I've cloned this from https://github.com/google/quiver-dart/pull/474.